### PR TITLE
QOLDEV-351 prepare for CKAN 2.10

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,19 @@
+[flake8]
+# @see https://flake8.pycqa.org/en/latest/user/configuration.html?highlight=.flake8
+
+exclude =
+    ckan
+
+# Extended output format.
+format = pylint
+
+# Show the source of errors.
+show_source = True
+statistics = True
+
+max-complexity = 10
+max-line-length = 127
+
+# List ignore rules one per line.
+ignore =
+    W503

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install requirements
         run: pip install flake8 pycodestyle
       - name: Check syntax
-        run: flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics --exclude ckan
+        run: flake8 .
 
   test:
     needs: lint

--- a/ckanext/resource_visibility/helpers.py
+++ b/ckanext/resource_visibility/helpers.py
@@ -60,14 +60,14 @@ def get_select_field_options(field_name, field_schema='resource_fields'):
             return tk.h.scheming_field_choices(field)
 
 
-def has_user_permission_for_org(org_id, user_obj, permission):
+def has_user_permission_for_org(org_id, user, permission):
     """
     Return False if user doesn't have permission in the organization.
     """
-    if user_obj is None:
+    if user is None:
         return False
 
-    context = {'user': user_obj.name}
+    context = {'user': user}
     data_dict = {'org_id': org_id, 'permission': permission}
     result = auth_functions.has_user_permission_for_org(context, data_dict)
 

--- a/ckanext/resource_visibility/logic/action.py
+++ b/ckanext/resource_visibility/logic/action.py
@@ -3,6 +3,7 @@ import ckan.plugins.toolkit as tk
 import ckanext.resource_visibility.constants as c
 from ckanext.resource_visibility.utils import user_is_editor_or_admin
 
+
 def _get_actions():
     return {
         "package_show": package_show,

--- a/ckanext/resource_visibility/plugin.py
+++ b/ckanext/resource_visibility/plugin.py
@@ -4,6 +4,7 @@ import ckan.plugins.toolkit as tk
 from . import constants as const, cli, utils, helpers, validators
 from .logic import action
 
+
 class ResourceVisibilityPlugin(p.SingletonPlugin):
 
     p.implements(p.IConfigurer)

--- a/ckanext/resource_visibility/templates/scheming/form_snippets/privacy_assessment_result.html
+++ b/ckanext/resource_visibility/templates/scheming/form_snippets/privacy_assessment_result.html
@@ -8,7 +8,7 @@
     {% set attrs = {"class": "form-control"} %}
 {% endif %}
 
-{% set user_allowed_to_edit = h.resource_visibility_has_user_permission_for_org(pkg_dict['owner_org'], g.userobj, 'create_dataset') %}
+{% set user_allowed_to_edit = h.resource_visibility_has_user_permission_for_org(pkg_dict['owner_org'], g.user, 'create_dataset') %}
 
 {% if user_allowed_to_edit %}
     {% call form.input(

--- a/ckanext/resource_visibility/tests/test_plugin.py
+++ b/ckanext/resource_visibility/tests/test_plugin.py
@@ -47,7 +47,8 @@ To temporary patch the CKAN configuration for the duration of a test you can use
     def test_some_action():
         pass
 """
-import ckanext.resource_visibility.plugin as plugin
+import ckanext.resource_visibility.plugin as plugin  # noqa
+
 
 def test_plugin():
     pass

--- a/ckanext/resource_visibility/utils.py
+++ b/ckanext/resource_visibility/utils.py
@@ -138,5 +138,4 @@ def _prepary_email_body(resources):
         'resources': resources
     }
 
-    return tk.render('emails/body/privacy_assessment_result.txt',
-                         extra_vars)
+    return tk.render('emails/body/privacy_assessment_result.txt', extra_vars)

--- a/ckanext/resource_visibility/validators.py
+++ b/ckanext/resource_visibility/validators.py
@@ -80,9 +80,8 @@ def privacy_assessment_result(key, data, errors, context):
 
         assessment_result = resource.extras.get(const.FIELD_ASSESS_RESULT)
 
-        if (assessment_result
-                and assessment_result == data[key]) or (not assessment_result
-                                                       and not data[key]):
+        if (assessment_result and assessment_result == data[key])\
+                or (not assessment_result and not data[key]):
             return
 
     # if there's no resource ID, it's a resource creation stage

--- a/setup.py
+++ b/setup.py
@@ -55,14 +55,14 @@ setup(
     # You can just specify the packages manually here if your project is
     # simple. Or you can use find_packages().
     packages=find_packages(exclude=['contrib', 'docs', 'tests*']),
-        namespace_packages=['ckanext'],
+    namespace_packages=['ckanext'],
 
     install_requires=[
-      # CKAN extensions should not list dependencies here, but in a separate
-      # ``requirements.txt`` file.
-      #
-      # http://docs.ckan.org/en/latest/extensions/best-practices.html
-      # add-third-party-libraries-to-requirements-txt
+        # CKAN extensions should not list dependencies here, but in a separate
+        # ``requirements.txt`` file.
+        #
+        # http://docs.ckan.org/en/latest/extensions/best-practices.html
+        # add-third-party-libraries-to-requirements-txt
     ],
 
     # If there are data files included in your packages that need to be


### PR DESCRIPTION
Make handling of user objects more robust; just pass username since that's what we want.

CKAN 2.10 seems to pass a name instead of a user object in the `g.userobj` field.